### PR TITLE
fix(erorrs): toast autoclose, err handling

### DIFF
--- a/src/components/predict/predict.tsx
+++ b/src/components/predict/predict.tsx
@@ -36,19 +36,25 @@ export default function Predict({ onPredict }: { onPredict: () => void }) {
             toast.update(toastID, {
                 render: 'Analysis Complete!',
                 type: 'success',
-                progress: 1,
-                autoClose: 5000
+                isLoading: false,
+                progress: 0.99
             })
-
             onPredict()
         })
-        .catch(() => {
+        .catch((err) => {
             toast.update(toastID, {
-                render: 'Error analyzing URL',
+                render: err.response?.data?.error || 'URL Analysis Failed',
                 type: 'error',
-                progress: 1,
-                autoClose: 5000
+                isLoading: false,
+                progress: 0.6
             })
+        })
+        .finally(() => {
+            setTimeout(() => {
+                toast.update(toastID, {
+                    progress: 1
+                })
+            }, 5000)
         })
 
         setLoading(false)


### PR DESCRIPTION
## Description
- Enabled the autoClosing of the toast based on 5 seconds after the toast had executed, and is done.
- Observation was made that using progress - and giving out value of `1` to it ends/dismisses the toast abruptly.
- Enabled the max value to be `0.99` to be sure that it stops there.

## Related Issue(s)
Fixes #1 

## Checklist
- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.
- [x] I have tested this code in the target environment.


